### PR TITLE
Fix cart to accumulate products in localStorage

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,10 +1,12 @@
-import { setLocalStorage } from "./utils.mjs";
+import { getLocalStorage, setLocalStorage } from "./utils.mjs";
 import ProductData from "./ProductData.mjs";
 
 const dataSource = new ProductData("tents");
 
 function addProductToCart(product) {
-  setLocalStorage("so-cart", product);
+  const cartItems = getLocalStorage("so-cart") || [];
+  cartItems.push(product);
+  setLocalStorage("so-cart", cartItems);
 }
 // add to cart button event handler
 async function addToCartHandler(e) {


### PR DESCRIPTION
Changed addProductToCart so the cart stores products in an array in localStorage instead of replacing the last one. Now adding more than one product shows them all in the cart